### PR TITLE
Patched glslang to support empty arguments in single-argument macros to match webgl glsl dialect

### DIFF
--- a/cmake/overlay-ports/glslang/allow-empty-functional-macro.patch
+++ b/cmake/overlay-ports/glslang/allow-empty-functional-macro.patch
@@ -1,0 +1,13 @@
+diff --git a/glslang/MachineIndependent/preprocessor/Pp.cpp b/glslang/MachineIndependent/preprocessor/Pp.cpp
+index 16b9d24..6af7c09 100644
+--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
++++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
+@@ -1300,8 +1300,6 @@ MacroExpandResult TPpContext::MacroExpand(TPpToken* ppToken, bool expandUndef, b
+ 
+             if (token == ')') {
+                 // closing paren of call
+-                if (in->mac->args.size() == 1 && !tokenRecorded)
+-                    break;
+                 arg++;
+                 break;
+             }

--- a/cmake/overlay-ports/glslang/portfile.cmake
+++ b/cmake/overlay-ports/glslang/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/glslang
+    REF "${VERSION}"
+    SHA512 45ec1a23a390319b9270761cf8befb832ac8b4bc215b211c41a543553a97e5ccf17c134c34d8fdbed6efe887a9a7c2f0a955d1bfe1add9e04cc3e95b12e1973a
+    HEAD_REF master
+    PATCHES "allow-empty-functional-macro.patch"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        opt ENABLE_OPT
+        opt ALLOW_EXTERNAL_SPIRV_TOOLS
+        tools ENABLE_GLSLANG_BINARIES
+        rtti ENABLE_RTTI
+)
+
+if (ENABLE_GLSLANG_BINARIES)
+    vcpkg_find_acquire_program(PYTHON3)
+    get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
+    vcpkg_add_to_path("${PYTHON_PATH}")
+endif ()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXTERNAL=OFF
+        -DGLSLANG_TESTS=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glslang DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/glslang-config.cmake"
+    [[${PACKAGE_PREFIX_DIR}/lib/cmake/glslang/glslang-targets.cmake]]
+    [[${CMAKE_CURRENT_LIST_DIR}/glslang-targets.cmake]]
+)
+file(REMOVE_RECURSE CONFIG_PATH "${CURRENT_PACKAGES_DIR}/lib/cmake" "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/glslang/Public/ShaderLang.h" "ifdef GLSLANG_IS_SHARED_LIBRARY" "if 1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/glslang/Include/glslang_c_interface.h" "ifdef GLSLANG_IS_SHARED_LIBRARY" "if 1")
+endif()
+
+vcpkg_copy_pdbs()
+
+if (ENABLE_GLSLANG_BINARIES)
+    vcpkg_copy_tools(TOOL_NAMES glslang glslangValidator spirv-remap AUTO_CLEAN)
+endif ()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/cmake/overlay-ports/glslang/usage
+++ b/cmake/overlay-ports/glslang/usage
@@ -1,0 +1,4 @@
+glslang provides CMake targets:
+
+    find_package(glslang CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glslang::SPVRemapper)

--- a/cmake/overlay-ports/glslang/vcpkg.json
+++ b/cmake/overlay-ports/glslang/vcpkg.json
@@ -1,0 +1,32 @@
+{
+    "name": "glslang",
+    "version": "14.0.0",
+    "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
+    "homepage": "https://github.com/KhronosGroup/glslang",
+    "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ],
+    "features": {
+        "opt": {
+            "description": "Build with spirv-opt capability",
+            "dependencies": [
+                "spirv-tools"
+            ]
+        },
+        "rtti": {
+            "description": "Build with dynamic typeinfo"
+        },
+        "tools": {
+            "description": "Build the glslangValidator and spirv-remap binaries",
+            "supports": "!ios"
+        }
+    }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,7 +27,8 @@
   "builtin-baseline": "b346ee32f13f3bf2ef19ac02f982f6938f7a84ea",
   "vcpkg-configuration": {
     "overlay-ports": [
-      "deps/Daxa"
+      "deps/Daxa",
+      "cmake/overlay-ports/glslang"
     ]
   }
 }


### PR DESCRIPTION
Upsteam pull request in order to fix one of the shaders mentioned in #5.

This fixes [tsKXR3](https://www.shadertoy.com/view/tsKXR3).